### PR TITLE
Use member functions for stdexec operations

### DIFF
--- a/include/io_uring/io_uring_context.hpp
+++ b/include/io_uring/io_uring_context.hpp
@@ -35,11 +35,8 @@ public:
   friend auto operator==(const scheduler_t &__lhs, const scheduler_t &__rhs)
       -> bool = default;
 
-  STDEXEC_MEMFN_FRIEND(schedule);
-
-  STDEXEC_MEMFN_DECL(auto schedule)
-  (this const scheduler_t &__sched)->__schedule_sender<scheduler_t> {
-    return __schedule_sender<scheduler_t>{.env = {__sched.__context_}};
+  auto schedule() const -> __schedule_sender<scheduler_t> {
+    return __schedule_sender<scheduler_t>{.env = {__context_}};
   }
 
   auto now() const noexcept { return std::chrono::steady_clock::now(); }

--- a/include/io_uring/ops/async_read_some.hpp
+++ b/include/io_uring/ops/async_read_some.hpp
@@ -87,26 +87,20 @@ struct async_read_some_sender {
                                      stdexec::set_error_t(std::exception_ptr),
                                      stdexec::set_stopped_t()>;
 
-  STDEXEC_MEMFN_DECL(auto get_env)
-  (this async_read_some_sender const &sender) noexcept -> env_t {
-    return sender.env;
-  }
+  auto get_env() const noexcept -> env_t { return env; }
 
   template <class Env>
-  STDEXEC_MEMFN_DECL(auto get_completion_signatures)
-  (this async_read_some_sender const &, Env) noexcept -> completion_sigs {
+  auto get_completion_signatures(Env) const noexcept -> completion_sigs {
     return {};
   }
 
   template <stdexec::receiver_of<completion_sigs> Receiver>
-  STDEXEC_MEMFN_DECL(auto connect)
-  (this async_read_some_sender const &sender, Receiver &&receiver)
-      -> stdexec::__t<
-          async_read_some_operation<stdexec::__id<Receiver>, Extent>> {
+  auto connect(Receiver &&receiver) const -> stdexec::__t<
+      async_read_some_operation<stdexec::__id<Receiver>, Extent>> {
     return stdexec::__t<
         async_read_some_operation<stdexec::__id<Receiver>, Extent>>(
-        std::in_place, *(sender.env.ctx), sender.fd, sender.buffer,
-        sender.offset, static_cast<Receiver &&>(receiver));
+        std::in_place, *(env.ctx), fd, buffer, offset,
+        static_cast<Receiver &&>(receiver));
   }
 };
 

--- a/include/io_uring/ops/async_write_some.hpp
+++ b/include/io_uring/ops/async_write_some.hpp
@@ -87,26 +87,20 @@ struct async_write_some_sender {
                                      stdexec::set_error_t(std::exception_ptr),
                                      stdexec::set_stopped_t()>;
 
-  STDEXEC_MEMFN_DECL(auto get_env)
-  (this async_write_some_sender const &sender) noexcept -> env_t {
-    return sender.env;
-  }
+  auto get_env() const noexcept -> env_t { return env; }
 
   template <class Env>
-  STDEXEC_MEMFN_DECL(auto get_completion_signatures)
-  (this async_write_some_sender const &, Env) noexcept -> completion_sigs {
+  auto get_completion_signatures(Env) const noexcept -> completion_sigs {
     return {};
   }
 
   template <stdexec::receiver_of<completion_sigs> Receiver>
-  STDEXEC_MEMFN_DECL(auto connect)
-  (this async_write_some_sender const &sender, Receiver &&receiver)
-      -> stdexec::__t<
-          async_write_some_operation<stdexec::__id<Receiver>, Extent>> {
+  auto connect(Receiver &&receiver) const -> stdexec::__t<
+      async_write_some_operation<stdexec::__id<Receiver>, Extent>> {
     return stdexec::__t<
         async_write_some_operation<stdexec::__id<Receiver>, Extent>>(
-        std::in_place, *(sender.env.ctx), sender.fd, sender.buffer,
-        sender.offset, static_cast<Receiver &&>(receiver));
+        std::in_place, *(env.ctx), fd, buffer, offset,
+        static_cast<Receiver &&>(receiver));
   }
 };
 

--- a/include/io_uring/ops/schedule.hpp
+++ b/include/io_uring/ops/schedule.hpp
@@ -70,24 +70,22 @@ private:
       stdexec::completion_signatures<stdexec::set_value_t(),
                                      stdexec::set_stopped_t()>;
 
+  // TODO doens't work with member function
   STDEXEC_MEMFN_DECL(auto get_env)
   (this const __schedule_sender &__sender) noexcept -> env_t {
     return __sender.env;
   }
 
   template <class _Env>
-  STDEXEC_MEMFN_DECL(auto get_completion_signatures)
-  (this const __schedule_sender &, _Env) noexcept -> __completion_sigs {
+  auto get_completion_signatures(_Env) const noexcept -> __completion_sigs {
     return {};
   }
 
   template <stdexec::receiver_of<__completion_sigs> _Receiver>
-  STDEXEC_MEMFN_DECL(auto connect)
-  (this const __schedule_sender &__sender, _Receiver &&__receiver)
+  auto connect(_Receiver &&__receiver) const
       -> stdexec::__t<__schedule_operation<stdexec::__id<_Receiver>>> {
     return stdexec::__t<__schedule_operation<stdexec::__id<_Receiver>>>(
-        std::in_place, *__sender.env.ctx,
-        static_cast<_Receiver &&>(__receiver));
+        std::in_place, *(env.ctx), static_cast<_Receiver &&>(__receiver));
   }
 };
 } // namespace __io_uring

--- a/include/io_uring/ops/schedule.hpp
+++ b/include/io_uring/ops/schedule.hpp
@@ -56,8 +56,7 @@ template <class _ReceiverId> struct __schedule_operation {
   using __t = __io_task_facade<__impl>;
 };
 
-template <typename Scheduler> class __schedule_sender {
-public:
+template <typename Scheduler> struct __schedule_sender {
   using env_t = io_uring_env_t<Scheduler>;
   env_t env;
 
@@ -65,16 +64,11 @@ public:
   using __id = __schedule_sender;
   using __t = __schedule_sender;
 
-private:
   using __completion_sigs =
       stdexec::completion_signatures<stdexec::set_value_t(),
                                      stdexec::set_stopped_t()>;
 
-  // TODO doens't work with member function
-  STDEXEC_MEMFN_DECL(auto get_env)
-  (this const __schedule_sender &__sender) noexcept -> env_t {
-    return __sender.env;
-  }
+  auto get_env() const noexcept -> env_t { return env; }
 
   template <class _Env>
   auto get_completion_signatures(_Env) const noexcept -> __completion_sigs {

--- a/include/io_uring/ops/schedule_after.hpp
+++ b/include/io_uring/ops/schedule_after.hpp
@@ -146,22 +146,21 @@ public:
   std::chrono::nanoseconds __duration_;
 
 private:
-  STDEXEC_MEMFN_DECL(auto get_env)
-  (this const __schedule_after_sender &__sender) noexcept -> env_t {
-    return __sender.__env_;
-  }
+  auto get_env() const noexcept -> env_t { return __env_; }
 
   using __completion_sigs =
       stdexec::completion_signatures<stdexec::set_value_t(),
                                      stdexec::set_error_t(std::exception_ptr),
                                      stdexec::set_stopped_t()>;
 
+  // TODO converting to member function doesn't work for this
   template <class _Env>
   STDEXEC_MEMFN_DECL(auto get_completion_signatures)
   (this const __schedule_after_sender &, _Env) noexcept -> __completion_sigs {
     return {};
   }
 
+  // TODO converting to member function doesn't work for this
   template <stdexec::receiver_of<__completion_sigs> _Receiver>
   STDEXEC_MEMFN_DECL(auto connect)
   (this const __schedule_after_sender &__sender, _Receiver &&__receiver)

--- a/include/io_uring/ops/schedule_after.hpp
+++ b/include/io_uring/ops/schedule_after.hpp
@@ -135,8 +135,7 @@ template <class _ReceiverId> struct __schedule_after_operation {
   using __t = __stoppable_task_facade_t<__impl>;
 };
 
-template <typename Scheduler> class __schedule_after_sender {
-public:
+template <typename Scheduler> struct __schedule_after_sender {
   using sender_concept = stdexec::sender_t;
   using __id = __schedule_after_sender;
   using __t = __schedule_after_sender;
@@ -145,7 +144,6 @@ public:
   env_t __env_;
   std::chrono::nanoseconds __duration_;
 
-private:
   auto get_env() const noexcept -> env_t { return __env_; }
 
   using __completion_sigs =
@@ -153,20 +151,16 @@ private:
                                      stdexec::set_error_t(std::exception_ptr),
                                      stdexec::set_stopped_t()>;
 
-  // TODO converting to member function doesn't work for this
   template <class _Env>
-  STDEXEC_MEMFN_DECL(auto get_completion_signatures)
-  (this const __schedule_after_sender &, _Env) noexcept -> __completion_sigs {
+  auto get_completion_signatures(_Env) const noexcept -> __completion_sigs {
     return {};
   }
 
-  // TODO converting to member function doesn't work for this
   template <stdexec::receiver_of<__completion_sigs> _Receiver>
-  STDEXEC_MEMFN_DECL(auto connect)
-  (this const __schedule_after_sender &__sender, _Receiver &&__receiver)
+  auto connect(_Receiver &&__receiver) const
       -> stdexec::__t<__schedule_after_operation<stdexec::__id<_Receiver>>> {
     return stdexec::__t<__schedule_after_operation<stdexec::__id<_Receiver>>>(
-        std::in_place, *__sender.__env_.ctx, __sender.__duration_,
+        std::in_place, *__env_.ctx, __duration_,
         static_cast<_Receiver &&>(__receiver));
   }
 };


### PR DESCRIPTION
stdexec now support member functions. So, the whole operations are moved to member functions because that is better for diagnostics as well as better for readability purposes.

connect operation was not migrated to member function in stdexec at time of operation. But moved it myself locally for stdexec now as that would be done in near future in stdexec too.